### PR TITLE
Add clickable prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,4 +24,4 @@ See instructions. Delete this line and place images of your UML Activity diagram
 
 ## Clickable Prototype
 
-See instructions. Delete this line and place a publicly-accessible link to your clickable prototype here.
+https://www.figma.com/proto/tJ4l0GGmRdSyLxzWis5bhX/Penguin?node-id=6-3&t=czR8NcqssgHpUiec-1&starting-point-node-id=6%3A3


### PR DESCRIPTION
From the instructions:
> Place a link to the published clickable prototype in the README.md file in the appropriate place. The link must not require a user to log in to view the prototype.

Here is a screenshot using an incognito browser (doesn't require user to log in):
<img width="2872" height="1734" alt="image" src="https://github.com/user-attachments/assets/7c51ef2b-500f-48ce-a007-88902198463d" />
